### PR TITLE
Removed redundant sys argument retrieval.

### DIFF
--- a/segmentator/__main__.py
+++ b/segmentator/__main__.py
@@ -7,21 +7,19 @@ Use config.py to hold arguments to be accessed by imported scripts.
 
 TODO: Argument parsing can be better structured, maybe by using parents. help
 looks a bit messy as is.
-
 """
 
-import sys
 import argparse
 import config as cfg
 from segmentator import __version__
 
 
-def main(args=None):
+def main():
     """Command line call argument parsing."""
-    if args is None:
-        args = sys.argv[1:]
-    # Main arguments
+    # Instantiate argument parser object:
     parser = argparse.ArgumentParser()
+
+    # Add arguments to namespace:
     parser.add_argument(
         'filename', metavar='path',
         help="Path to input. Mostly a nifti file with image data."


### PR DESCRIPTION
I removed the redundant `sys` argument retrieval. The input arguments were retrieved twice, once using `sys`, and once using `argparse`. The list (`args`) retrieved with `sys` was subsequently overwritten by a namespace object from `argparse`. This is just a suggestion, but I think it is more pythonic not include redundant code.